### PR TITLE
feat: 修改了user.py的uid为str，permission的比较加上.value

### DIFF
--- a/Routers/user.py
+++ b/Routers/user.py
@@ -185,30 +185,22 @@ async def user_recover(
 
 @user_router.put("/profile/{uid}", response_model=BaseResponse)
 async def user_update(
-    uid: str,
+    uid: UUID,
     body: UpdateUser,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> StandardResponse[None]:
-    print(body.permission)
-
-    if uid != user.uid:
-        print(uid)
-        print(user.uid)
+    if uid.hex != user.uid:
         assert verify_user(user, Permission.ADMIN)
 
-    if (record := db.query(UserDb).filter(UserDb.uid == uid).first()) is not None:
-        print("found")
+    if (record := db.query(UserDb).filter(UserDb.uid == uid.hex).first()) is not None:
         if body.birthday is not None:
             record.birthday = body.birthday
         if body.gender is not None:
             record.gender = body.gender.value
         
         if body.permission is not None and record.permission != body.permission.value:
-
-            print("equal")
             assert verify_user(user, Permission.ADMIN)
-            print("can do")
             record.permission = body.permission()
         if body.password is not None:
             record.password = bcrypt.hashpw(

--- a/Routers/user.py
+++ b/Routers/user.py
@@ -185,26 +185,36 @@ async def user_recover(
 
 @user_router.put("/profile/{uid}", response_model=BaseResponse)
 async def user_update(
-    uid: UUID,
+    uid: str,
     body: UpdateUser,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> StandardResponse[None]:
+    print(body.permission)
+
     if uid != user.uid:
+        print(uid)
+        print(user.uid)
         assert verify_user(user, Permission.ADMIN)
 
     if (record := db.query(UserDb).filter(UserDb.uid == uid).first()) is not None:
-        if body.gender is not None:
-            record.gender = body.gender.value
+        print("found")
         if body.birthday is not None:
             record.birthday = body.birthday
-        if body.permission is not None and record.permission != body.permission:
+        if body.gender is not None:
+            record.gender = body.gender.value
+        
+        if body.permission is not None and record.permission != body.permission.value:
+
+            print("equal")
             assert verify_user(user, Permission.ADMIN)
+            print("can do")
             record.permission = body.permission()
         if body.password is not None:
             record.password = bcrypt.hashpw(
                 bytes(body.password, "utf-8"), bcrypt.gensalt()
             ).decode("utf-8")
+        # db.query().filter().update
         db.commit()
         return StandardResponse[None](status_code=200, message="User updated")
     else:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the user update functionality in the `user.py` router. It changes how the user ID is handled and improves the conditions for updating user attributes.

### Detailed summary
- Changed the comparison of `uid` to `user.uid` from `if uid != user.uid:` to `if uid.hex != user.uid:`.
- Updated the query to filter by `uid.hex` instead of `uid`.
- Added a condition to check `body.gender` before updating `record.gender`.
- Adjusted the permission check to use `body.permission.value` instead of `body.permission`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->